### PR TITLE
Use `satisfies` keyword instead of Prisma.validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@nestia/e2e": "^0.3.7",
     "@nestia/sdk": "^2.3.9",
-    "@trivago/prettier-plugin-sort-imports": "^3.3.0",
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/cli": "^0.11.19",
     "@types/express": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "inquirer": "^8.2.5",
     "nestia": "^5.0.2",
     "pm2": "^4.5.6",
-    "prettier": "^2.6.2",
+    "prettier": "^3.1.0",
     "prettier-plugin-prisma": "^5.0.0",
     "rimraf": "^3.0.2",
     "sloc": "^0.2.1",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,20 +1,18 @@
 module.exports = {
-    parser: "typescript",
-    printWidth: 80,
-    semi: true,
-    tabWidth: 2,
-    trailingComma: "all",
-    importOrder: [
-        "<THIRD_PARTY_MODULES>",
-        "^@samchon/bbs-api(.*)$",
-        "^@samchon/bbs-models(.*)$",
-        "(.*)providers/(.*)$",
-        "^[./]"
-    ],
-    importOrderSeparation: true,
-    importOrderSortSpecifiers: true,
-    importOrderParserPlugins: [
-        "decorators-legacy",
-        "typescript",
-    ]
+  parser: "typescript",
+  printWidth: 80,
+  semi: true,
+  tabWidth: 2,
+  trailingComma: "all",
+  plugins: ["@trivago/prettier-plugin-sort-imports"],
+  importOrder: [
+    "<THIRD_PARTY_MODULES>",
+    "^@samchon/bbs-api(.*)$",
+    "^@samchon/bbs-models(.*)$",
+    "(.*)providers/(.*)$",
+    "^[./]",
+  ],
+  importOrderSeparation: true,
+  importOrderSortSpecifiers: true,
+  importOrderParserPlugins: ["decorators-legacy", "typescript"],
 };

--- a/src/providers/bbs/BbsArticleCommentProvider.ts
+++ b/src/providers/bbs/BbsArticleCommentProvider.ts
@@ -28,11 +28,11 @@ export namespace BbsArticleCommentProvider {
       created_at: input.created_at.toISOString(),
     });
     export const select = () =>
-      Prisma.validator<Prisma.bbs_article_commentsFindManyArgs>()({
+      ({
         include: {
           snapshots: BbsArticleCommentSnapshotProvider.json.select(),
         } as const,
-      });
+      }) satisfies Prisma.bbs_article_commentsFindManyArgs;
   }
 
   /* -----------------------------------------------------------
@@ -82,7 +82,7 @@ export namespace BbsArticleCommentProvider {
     };
 
   const search = (input: IBbsArticleComment.IRequest.ISearch | undefined) =>
-    Prisma.validator<Prisma.bbs_article_commentsWhereInput["AND"]>()([
+    [
       ...(input?.writer?.length
         ? [
             {
@@ -105,19 +105,17 @@ export namespace BbsArticleCommentProvider {
             },
           ]
         : []),
-    ]);
+    ] satisfies Prisma.bbs_article_commentsWhereInput["AND"];
 
   const orderBy = (
     key: IBbsArticleComment.IRequest.SortableColumns,
     value: "asc" | "desc",
   ) =>
-    Prisma.validator<Prisma.bbs_article_commentsOrderByWithRelationInput>()(
-      key === "writer"
-        ? { writer: value }
-        : {
-            created_at: value,
-          },
-    );
+    (key === "writer"
+      ? { writer: value }
+      : {
+          created_at: value,
+        }) satisfies Prisma.bbs_article_commentsOrderByWithRelationInput;
 
   /* -----------------------------------------------------------
     WRITERS

--- a/src/providers/bbs/BbsArticleCommentSnapshotProvider.ts
+++ b/src/providers/bbs/BbsArticleCommentSnapshotProvider.ts
@@ -23,7 +23,7 @@ export namespace BbsArticleCommentSnapshotProvider {
       created_at: input.created_at.toISOString(),
     });
     export const select = () =>
-      Prisma.validator<Prisma.bbs_article_comment_snapshotsFindManyArgs>()({
+      ({
         include: {
           to_files: {
             include: {
@@ -31,7 +31,7 @@ export namespace BbsArticleCommentSnapshotProvider {
             },
           },
         } as const,
-      });
+      }) satisfies Prisma.bbs_article_comment_snapshotsFindManyArgs;
   }
 
   export const create =
@@ -52,22 +52,20 @@ export namespace BbsArticleCommentSnapshotProvider {
     };
 
   export const collect = (input: IBbsArticleComment.IUpdate, ip: string) =>
-    Prisma.validator<Prisma.bbs_article_comment_snapshotsCreateWithoutCommentInput>()(
-      {
-        id: v4(),
-        format: input.format,
-        body: input.body,
-        ip,
-        created_at: new Date(),
-        to_files: {
-          create: input.files.map((file, i) => ({
-            id: v4(),
-            file: {
-              create: AttachmentFileProvider.collect(file),
-            },
-            sequence: i,
-          })),
-        },
+    ({
+      id: v4(),
+      format: input.format,
+      body: input.body,
+      ip,
+      created_at: new Date(),
+      to_files: {
+        create: input.files.map((file, i) => ({
+          id: v4(),
+          file: {
+            create: AttachmentFileProvider.collect(file),
+          },
+          sequence: i,
+        })),
       },
-    );
+    }) satisfies Prisma.bbs_article_comment_snapshotsCreateWithoutCommentInput;
 }

--- a/src/providers/bbs/BbsArticleProvider.ts
+++ b/src/providers/bbs/BbsArticleProvider.ts
@@ -28,11 +28,11 @@ export namespace BbsArticleProvider {
     });
 
     export const select = () =>
-      Prisma.validator<Prisma.bbs_articlesFindManyArgs>()({
+      ({
         include: {
           snapshots: BbsArticleSnapshotProvider.json.select(),
         } as const,
-      });
+      }) satisfies Prisma.bbs_articlesFindManyArgs;
   }
 
   export namespace abridge {
@@ -51,7 +51,7 @@ export namespace BbsArticleProvider {
       ),
     });
     export const select = () =>
-      Prisma.validator<Prisma.bbs_articlesFindManyArgs>()({
+      ({
         include: {
           mv_last: {
             include: {
@@ -67,7 +67,7 @@ export namespace BbsArticleProvider {
             },
           },
         } as const,
-      });
+      }) satisfies Prisma.bbs_articlesFindManyArgs;
   }
 
   export namespace summarize {
@@ -81,7 +81,7 @@ export namespace BbsArticleProvider {
       updated_at: input.mv_last!.snapshot.created_at.toISOString(),
     });
     export const select = () =>
-      Prisma.validator<Prisma.bbs_articlesFindManyArgs>()({
+      ({
         include: {
           mv_last: {
             include: {
@@ -94,7 +94,7 @@ export namespace BbsArticleProvider {
             },
           },
         } as const,
-      });
+      }) satisfies Prisma.bbs_articlesFindManyArgs;
   }
 
   /* -----------------------------------------------------------
@@ -144,7 +144,7 @@ export namespace BbsArticleProvider {
   };
 
   const search = (input: IBbsArticle.IRequest.ISearch | undefined) =>
-    Prisma.validator<Prisma.bbs_articlesWhereInput["AND"]>()([
+    [
       ...(input?.writer?.length
         ? [{ writer: { contains: input.writer } }]
         : []),
@@ -216,22 +216,22 @@ export namespace BbsArticleProvider {
             },
           ]
         : []),
-    ]);
+    ] satisfies Prisma.bbs_articlesWhereInput["AND"];
 
   const orderBy = (
     key: IBbsArticle.IRequest.SortableColumns,
     value: "asc" | "desc",
   ) =>
-    Prisma.validator<Prisma.bbs_articlesOrderByWithRelationInput>()(
-      key === "writer"
-        ? { writer: value }
-        : key === "title"
+    (key === "writer"
+      ? { writer: value }
+      : key === "title"
         ? { mv_last: { snapshot: { title: value } } }
         : key === "created_at"
-        ? { created_at: value }
-        : // updated_at
-          { mv_last: { snapshot: { created_at: value } } },
-    );
+          ? { created_at: value }
+          : // updated_at
+            {
+              mv_last: { snapshot: { created_at: value } },
+            }) satisfies Prisma.bbs_articlesOrderByWithRelationInput;
 
   /* -----------------------------------------------------------
     WRITERS

--- a/src/providers/bbs/BbsArticleSnapshotProvider.ts
+++ b/src/providers/bbs/BbsArticleSnapshotProvider.ts
@@ -22,7 +22,7 @@ export namespace BbsArticleSnapshotProvider {
       created_at: input.created_at.toISOString(),
     });
     export const select = () =>
-      Prisma.validator<Prisma.bbs_article_snapshotsFindManyArgs>()({
+      ({
         include: {
           to_files: {
             include: {
@@ -30,7 +30,7 @@ export namespace BbsArticleSnapshotProvider {
             },
           },
         } as const,
-      });
+      }) satisfies Prisma.bbs_article_snapshotsFindManyArgs;
   }
 
   export const store =
@@ -58,7 +58,7 @@ export namespace BbsArticleSnapshotProvider {
     };
 
   export const collect = (input: IBbsArticle.IUpdate, ip: string) =>
-    Prisma.validator<Prisma.bbs_article_snapshotsCreateWithoutArticleInput>()({
+    ({
       id: v4(),
       title: input.title,
       format: input.format,
@@ -74,5 +74,5 @@ export namespace BbsArticleSnapshotProvider {
           sequence: i,
         })),
       },
-    });
+    }) satisfies Prisma.bbs_article_snapshotsCreateWithoutArticleInput;
 }

--- a/src/providers/common/AttachmentFileProvider.ts
+++ b/src/providers/common/AttachmentFileProvider.ts
@@ -16,15 +16,15 @@ export namespace AttachmentFileProvider {
       created_at: input.created_at.toISOString(),
     });
     export const select = () =>
-      Prisma.validator<Prisma.attachment_filesFindManyArgs>()({});
+      ({}) satisfies Prisma.attachment_filesFindManyArgs;
   }
 
   export const collect = (input: IAttachmentFile.IStore) =>
-    Prisma.validator<Prisma.attachment_filesCreateInput>()({
+    ({
       id: v4(),
       name: input.name,
       extension: input.extension,
       url: input.url,
       created_at: new Date(),
-    });
+    }) satisfies Prisma.attachment_filesCreateInput;
 }


### PR DESCRIPTION
This pull request introduces the utilization of the `satisfies` operator in place of `Prisma.validator`. 

The `satisfies` operator provides the same benefits with no runtime impact and provides the same functionality just as `Prisma.validator`.

see: [https://www.prisma.io/blog/satisfies-operator-ur8ys8ccq7zb](https://www.prisma.io/blog/satisfies-operator-ur8ys8ccq7zb)