### PR TITLE
Support `pnpm` in the `webpack` configuration.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,8 +54,11 @@ module.exports = {
           to: "[name][ext]",
         },
         {
-          from: "./node_modules/.prisma/client/*.node",
+          from: "./node_modules/**/.prisma/client/*.node",
           to: () => Promise.resolve("[path][name][ext]"),
+          globOptions: {
+            dot: true,
+          },
         },
       ],
     }),


### PR DESCRIPTION
Special case for prisma binary files' copying.