### PR TITLE
URI instead of URL.

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -8,7 +8,7 @@
 erDiagram
 "attachment_files" {
     String id PK
-    String name "nullable"
+    String name
     String extension "nullable"
     String url
     DateTime created_at
@@ -73,15 +73,9 @@ Attachment File.
 
 Every attachment files that are managed in current system.
 
-For reference, it is possible to omit one of file name or extension like 
-`.gitignore` or `README` case, but not possible to omit both of them.
-
 **Properties**
   - `id`: 
-  - `name`
-    > File name, except extension.
-    > 
-    > Possible to omit like `.gitignore` case.
+  - `name`: File name, except extension.
   - `extension`
     > Extension.
     > 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/bbs-backend",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Backend for bbs",
   "scripts": {
     "test": "rimraf prisma/migrations && node bin/test",
@@ -38,8 +38,8 @@
   },
   "homepage": "https://github.com/samchon/bbs-backend",
   "devDependencies": {
-    "@nestia/e2e": "^0.4.0",
-    "@nestia/sdk": "^2.4.5",
+    "@nestia/e2e": "^0.4.1",
+    "@nestia/sdk": "^2.4.6",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/cli": "^0.11.19",
@@ -75,8 +75,8 @@
     "write-file-webpack-plugin": "^4.5.1"
   },
   "dependencies": {
-    "@nestia/core": "^2.4.5",
-    "@nestia/fetcher": "^2.4.5",
+    "@nestia/core": "^2.4.6",
+    "@nestia/fetcher": "^2.4.6",
     "@nestjs/common": "^10.2.10",
     "@nestjs/core": "^10.2.10",
     "@nestjs/platform-fastify": "^10.2.10",
@@ -93,7 +93,7 @@
     "serialize-error": "^4.1.0",
     "source-map-support": "^0.5.19",
     "tstl": "^2.5.13",
-    "typia": "^5.3.12",
+    "typia": "^5.4.1",
     "uuid": "^9.0.1"
   },
   "private": true

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samchon/bbs-api",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "API for bbs",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -15,8 +15,8 @@
   },
   "homepage": "https://github.com/samchon/bbs-backend#readme",
   "dependencies": {
-    "@nestia/fetcher": "^2.4.4",
-    "typia": "^5.3.9"
+    "@nestia/fetcher": "^2.4.6",
+    "typia": "^5.4.1"
   },
   "include": [
     "lib",

--- a/packages/api/swagger.json
+++ b/packages/api/swagger.json
@@ -7,7 +7,7 @@
     }
   ],
   "info": {
-    "version": "2.0.1",
+    "version": "2.0.2",
     "title": "@samchon/bbs-backend",
     "description": "Backend for bbs",
     "license": {
@@ -755,9 +755,7 @@
           "name": {
             "type": "string",
             "maxLength": 255,
-            "minLength": 1,
-            "nullable": true,
-            "description": "File name, except extension.\n\nPossible to omit like `.gitignore` case."
+            "description": "File name, except extension."
           },
           "extension": {
             "type": "string",
@@ -768,7 +766,7 @@
           },
           "url": {
             "type": "string",
-            "format": "url",
+            "format": "uri",
             "description": "URL path of the real file."
           }
         },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,9 +22,6 @@ generator markdown {
 ///
 /// Every attachment files that are managed in current system.
 ///
-/// For reference, it is possible to omit one of file name or extension like 
-/// `.gitignore` or `README` case, but not possible to omit both of them.
-///
 /// @namespace Articles
 /// @author Samchon
 model attachment_files {
@@ -36,11 +33,8 @@ model attachment_files {
 
   /// File name, except extension.
   ///
-  /// Possible to omit like `.gitignore` case.
-  ///
-  /// @minLength 1
   /// @maxLength 255
-  name String? @db.VarChar
+  name String @db.VarChar
 
   /// Extension.
   ///

--- a/src/api/structures/common/IAttachmentFile.ts
+++ b/src/api/structures/common/IAttachmentFile.ts
@@ -5,9 +5,7 @@ import { tags } from "typia";
  *
  * Every attachment files that are managed in current system.
  *
- * For reference, it is possible to omit one of file {@link name}
- * or {@link extension} like `.gitignore` or `README` case, but not
- * possible to omit both of them.
+ * @author Samchon
  */
 export interface IAttachmentFile extends IAttachmentFile.ICreate {
   /**
@@ -25,10 +23,8 @@ export namespace IAttachmentFile {
   export interface ICreate {
     /**
      * File name, except extension.
-     *
-     * Possible to omit like `.gitignore` case.
      */
-    name: null | (string & tags.MinLength<1> & tags.MaxLength<255>);
+    name: string & tags.MaxLength<255>;
 
     /**
      * Extension.
@@ -40,6 +36,6 @@ export namespace IAttachmentFile {
     /**
      * URL path of the real file.
      */
-    url: string & tags.Format<"url">;
+    url: string & tags.Format<"uri">;
   }
 }


### PR DESCRIPTION
As `url` format has been deprecated in the recent OpenAPI and JSON Schema spec, this server also follows the rule.
